### PR TITLE
Support new refreshDisabled setting for git and svn repository caches

### DIFF
--- a/bower.conf.json
+++ b/bower.conf.json
@@ -26,6 +26,7 @@
             "port": 6789,
             "protocol": "git",
             "publicAccessURL": null,
+            "refreshDisabled": false,
             "refreshTimeout": 10,
             "parameters": {
                 "timeout": 60000,
@@ -39,6 +40,7 @@
             "port": 7891,
             "protocol": "svn",
             "publicAccessURL": null,
+            "refreshDisabled": false,
             "refreshTimeout": 10
         }
     },

--- a/lib/infrastructure/configurationManager.js
+++ b/lib/infrastructure/configurationManager.js
@@ -58,6 +58,7 @@ module.exports = function ConfigurationManager() {
                     hostName: self.config.repositoryCache.svn.host,
                     port: self.config.repositoryCache.svn.port || 7891,
                     protocol: self.config.repositoryCache.svn.protocol || 'svn',
+                    refreshDisabled: self.config.repositoryCache.svn.refreshDisabled || false, 
                     refreshTimeout: self.config.repositoryCache.svn.refreshTimeout || 10,
                     parameters: self.config.repositoryCache.svn.parameters
                 };
@@ -70,6 +71,7 @@ module.exports = function ConfigurationManager() {
                     publicAccessURL: self.config.repositoryCache.git.publicAccessURL || null,
                     port: self.config.repositoryCache.git.port || 6789,
                     protocol: self.config.repositoryCache.git.protocol || 'git',
+                    refreshDisabled: self.config.repositoryCache.git.refreshDisabled || false,
                     refreshTimeout: self.config.repositoryCache.git.refreshTimeout || 10,
                     parameters: self.config.repositoryCache.git.parameters
                 };

--- a/lib/service/repoCaches/gitRepoCache.js
+++ b/lib/service/repoCaches/gitRepoCache.js
@@ -18,7 +18,12 @@ module.exports = function GitRepoCache(options) {
             .then(_checkGitInstalled)
             .then(function() {
                 return new Promise(function(resolve) {
-                    setInterval(_getLatestForRepos, options.refreshTimeout * 60 * 1000);
+                    if (options.refreshDisabled) {
+                        logger.log('Refresh of cached Git repositories is disabled');
+                    }
+                    else {
+                        setInterval(_getLatestForRepos, options.refreshTimeout * 60 * 1000);
+                    }
                     resolve();
                 });
             })

--- a/lib/service/repoCaches/svnRepoCache.js
+++ b/lib/service/repoCaches/svnRepoCache.js
@@ -16,7 +16,12 @@ module.exports = function SvnRepoCache(options) {
         return _createDirectory(options.repoCacheRoot)
             .then(_checkSvnInstalled)
             .then(function() {
-                setInterval(_getLatestForRepos, options.refreshTimeout * 60 * 1000);
+                if (options.refreshDisabled) {
+                    logger.log('Refresh of cached SVN repositories is disabled');
+                }
+                else {
+                    setInterval(_getLatestForRepos, options.refreshTimeout * 60 * 1000);
+                }
             })
             .then(_startSvnDaemon)
             .catch(function(err) {


### PR DESCRIPTION
The `refreshDisabled` setting allows for control over when the `private-bower` server actually calls out to the public registry for cached repositories.

When `refreshDisabled` is set to `true` for a repository cache, we require that all updates to that repository cache must be performed manually.

The new flag can be used in situations where outgoing connections are either not permitted or need to be closely managed.

This is implemented by not creating an interval-driven task to update the repositories in the cache.
